### PR TITLE
fix wrong separator

### DIFF
--- a/Traits/FactoryLocatorTrait.php
+++ b/Traits/FactoryLocatorTrait.php
@@ -8,9 +8,10 @@ trait FactoryLocatorTrait
 {
     protected static function newFactory(): Factory
     {
-        $containersFactoriesPath = DIRECTORY_SEPARATOR . 'Data' . DIRECTORY_SEPARATOR . 'Factories' . DIRECTORY_SEPARATOR;
-        $containerName = explode(DIRECTORY_SEPARATOR, static::class)[2];
-        $nameSpace = 'App' . DIRECTORY_SEPARATOR . 'Containers' . DIRECTORY_SEPARATOR . $containerName . $containersFactoriesPath;
+        $separator = '\\';
+        $containersFactoriesPath = $separator . 'Data' . $separator . 'Factories' . $separator;
+        $containerName = explode($separator, static::class)[2];
+        $nameSpace = 'App' . $separator . 'Containers' . $separator . $containerName . $containersFactoriesPath;
 
         Factory::useNamespace($nameSpace);
         $className = class_basename(static::class);


### PR DESCRIPTION
this PR fixes an error that occurs when running tests on macOS / Linux systems
The error occurs due to the use of the predefined constant DIRECTORY_SEPARATOR, which is "\\" for Windows and "/" for Linux / MacOS.

The error itself:
"Undefined offset: 2"
apiato/core/Traits/FactoryLocatorTrait.php:12
`$containerName = explode(DIRECTORY_SEPARATOR, static::class)[2];`